### PR TITLE
RC-10: make registrationCoreService bean visible to other modules

### DIFF
--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -46,7 +46,7 @@
     <!-- Services accessible via Context.getService() -->
     <bean parent="serviceContext">
         <property name="moduleService">
-            <list merge="true">
+            <list>
                 <value>${project.parent.groupId}.${project.parent.artifactId}.api.RegistrationCoreService</value>
                 <ref local="registrationCoreService" />
             </list>

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -23,6 +23,9 @@
     <require_module version="${idgenVersion}">
         org.openmrs.module.idgen
     </require_module>
+        <require_module version="${eventVersion}">
+            org.openmrs.event
+        </require_module>
     </require_modules>
 
 	

--- a/pom.xml
+++ b/pom.xml
@@ -35,8 +35,8 @@
 
 	<properties>
 		<openMRSVersion>1.8.2</openMRSVersion>
-		<idgenVersion>2.3</idgenVersion>
-		<eventVersion>2.0.2-SNAPSHOT</eventVersion>
+		<idgenVersion>2.6-SNAPSHOT</idgenVersion>
+		<eventVersion>2.1</eventVersion>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 


### PR DESCRIPTION
Just refactored moduleApplicationContext.xml so registrationCoreService bean could be referenced as SpringBean in other modules
