### PR TITLE
RC-32: GP 'identifierSourceId' to support UUIDs and not only IDs.

### DIFF
--- a/api/src/main/java/org/openmrs/module/registrationcore/api/impl/RegistrationCoreProperties.java
+++ b/api/src/main/java/org/openmrs/module/registrationcore/api/impl/RegistrationCoreProperties.java
@@ -30,9 +30,21 @@ public class RegistrationCoreProperties extends ModuleProperties implements Appl
 		this.applicationContext = applicationContext;
 	}
 	
+	/**
+	 * @deprecated as of 1.9.0, replaced by {@link #getSourceIdentifier()}
+	 */
+	@Deprecated
 	public Integer getOpenMrsIdentifierSourceId() {
 		String propertyName = RegistrationCoreConstants.GP_OPENMRS_IDENTIFIER_SOURCE_ID;
 		return getIntegerProperty(propertyName);
+	}
+	
+	/**
+	 * @return identifier source uuid or id
+	 */
+	public String getSourceIdentifier() {
+		String propertyName = RegistrationCoreConstants.GP_OPENMRS_IDENTIFIER_SOURCE_ID;
+		return getProperty(propertyName);
 	}
 	
 	public String getOpenMrsIdentifierUuid() {

--- a/api/src/main/java/org/openmrs/module/registrationcore/api/impl/RegistrationCoreServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/registrationcore/api/impl/RegistrationCoreServiceImpl.java
@@ -56,8 +56,6 @@ import org.openmrs.module.registrationcore.api.search.SimilarPatientSearchAlgori
 import org.openmrs.module.registrationcore.api.mpi.common.MpiProperties;
 import org.openmrs.validator.PatientIdentifierValidator;
 import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.transaction.annotation.Transactional;
@@ -491,10 +489,14 @@ public class RegistrationCoreServiceImpl extends BaseOpenmrsService implements R
 	private IdentifierSourceService getIssAndUpdateIdSource() {
 		IdentifierSourceService iss = Context.getService(IdentifierSourceService.class);
 		if (idSource == null) {
-			Integer idSourceId = registrationCoreProperties.getOpenMrsIdentifierSourceId();
-			idSource = iss.getIdentifierSource(idSourceId);
+			String sourceIdentifier = registrationCoreProperties.getSourceIdentifier();
+			if (StringUtils.isNumeric(sourceIdentifier)) {
+				idSource = iss.getIdentifierSource(Integer.valueOf(sourceIdentifier));
+			} else {
+				idSource = iss.getIdentifierSourceByUuid(sourceIdentifier);
+			}
 			if (idSource == null) {
-				throw new APIException("cannot find identifier source with id:" + idSourceId);
+				throw new APIException("cannot find identifier source with id:" + sourceIdentifier);
 			}
 		}
 		return iss;

--- a/api/src/main/java/org/openmrs/module/registrationcore/api/mpi/openempi/OpenEmpiPatientFetcher.java
+++ b/api/src/main/java/org/openmrs/module/registrationcore/api/mpi/openempi/OpenEmpiPatientFetcher.java
@@ -68,7 +68,7 @@ public class OpenEmpiPatientFetcher implements MpiPatientFetcher {
 	
 	private void addOpenMrsIdentifier(Patient patient) {
 		log.info("Generate OpenMRS identifier for imported Mpi patient.");
-		Integer openMrsIdentifierId = coreProperties.getOpenMrsIdentifierSourceId();
+		String openMrsIdentifierId = coreProperties.getSourceIdentifier();
 		PatientIdentifier identifier = identifierBuilder.generateIdentifier(openMrsIdentifierId, null);
 		identifier.setPreferred(true);
 		patient.addIdentifier(identifier);

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -136,4 +136,13 @@
 
     <bean id="registrationcore.openEmpiPatientFilter"
           class="org.openmrs.module.registrationcore.api.mpi.openempi.OpenEmpiPatientFilter"/>
+          
+    <!-- Add global property listeners -->
+	<bean id="registrationcore.globalPropertyListeners" parent="openmrsEventListeners">
+	    <property name="globalPropertyListeners">
+	        <list value-type="org.openmrs.api.GlobalPropertyListener" merge="true">
+	            <bean class="${project.parent.groupId}.${project.parent.artifactId}.api.impl.RegistrationCoreServiceImpl" />
+	        </list>
+	    </property>
+	</bean>
 </beans>

--- a/api/src/test/java/org/openmrs/module/registrationcore/api/RegistrationCoreServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/registrationcore/api/RegistrationCoreServiceTest.java
@@ -34,6 +34,7 @@ import org.openmrs.api.PatientService;
 import org.openmrs.api.PersonService;
 import org.openmrs.api.context.Context;
 import org.openmrs.event.Event;
+import org.openmrs.module.idgen.service.IdentifierSourceService;
 import org.openmrs.module.registrationcore.RegistrationCoreConstants;
 import org.openmrs.module.registrationcore.RegistrationData;
 import org.openmrs.module.registrationcore.api.biometrics.model.BiometricData;
@@ -286,6 +287,16 @@ public class RegistrationCoreServiceTest extends BaseRegistrationCoreSensitiveTe
 		assertEquals("LEFT-INDEX", fingerprint.getType());
 		assertEquals("ISO", fingerprint.getFormat());
 		assertEquals("xxxyyyzzz", fingerprint.getTemplate());
+	}
+	
+	@Test
+	public void registerPatient_shouldAlsoConsumeUuidAsValueForIdentifierSourceIdGP() {
+		String sourceUuid = Context.getService(IdentifierSourceService.class).getIdentifierSource(1).getUuid();
+		adminService.saveGlobalProperty(
+		    new GlobalProperty(RegistrationCoreConstants.GP_OPENMRS_IDENTIFIER_SOURCE_ID, sourceUuid));
+		Location location = locationService.getLocation(2);
+		Patient registeredPatient = service.registerPatient(createBasicPatient(), null, null, location);
+		assertNotNull(registeredPatient);
 	}
 	
 	private RegistrationData getSampleRegistrationDataWithBiometrics() {

--- a/api/src/test/java/org/openmrs/module/registrationcore/api/impl/IdentifierBuilderTest.java
+++ b/api/src/test/java/org/openmrs/module/registrationcore/api/impl/IdentifierBuilderTest.java
@@ -19,7 +19,9 @@ import static org.mockito.Mockito.*;
 
 public class IdentifierBuilderTest {
 	
-	private static final String OPENMRS_IDENTIFIER_SOURCE_ID = "1";
+	private static final Integer OPENMRS_IDENTIFIER_SOURCE_ID = 1;
+	
+	private static final String OPENMRS_IDENTIFIER_SOURCE_STRING_ID = "1";
 	
 	private static final String OPENMRS_GENERATED_IDENTIFIER = "10012NF";
 	
@@ -65,8 +67,7 @@ public class IdentifierBuilderTest {
 		mockIdentifierSource(identifierSource);
 		mockGeneratedIdentifier();
 		
-		PatientIdentifier patientIdentifier = generator.generateIdentifier(Integer.valueOf(OPENMRS_IDENTIFIER_SOURCE_ID),
-		    null);
+		PatientIdentifier patientIdentifier = generator.generateIdentifier(OPENMRS_IDENTIFIER_SOURCE_STRING_ID, null);
 		
 		verify(locationService).getDefaultLocation();
 		verify(iss).getIdentifierSource(Integer.valueOf(OPENMRS_IDENTIFIER_SOURCE_ID));
@@ -96,7 +97,7 @@ public class IdentifierBuilderTest {
 		mockIdentifierSource(identifierSource);
 		mockGeneratedIdentifier();
 		
-		PatientIdentifier patientIdentifier = generator.generateIdentifier(Integer.valueOf(OPENMRS_IDENTIFIER_SOURCE_ID),
+		PatientIdentifier patientIdentifier = generator.generateIdentifier(OPENMRS_IDENTIFIER_SOURCE_STRING_ID,
 		    customLocation);
 		
 		verify(locationService, never()).getDefaultLocation();
@@ -111,7 +112,7 @@ public class IdentifierBuilderTest {
 	public void testGenerateIdentifierThrowExceptionOnEmptyDefaultLocation() throws Exception {
 		mockDefaultLocation(null);
 		
-		generator.generateIdentifier(Integer.valueOf(OPENMRS_IDENTIFIER_SOURCE_ID), null);
+		generator.generateIdentifier(OPENMRS_IDENTIFIER_SOURCE_STRING_ID, null);
 	}
 	
 	@Test(expected = APIException.class)
@@ -119,7 +120,7 @@ public class IdentifierBuilderTest {
 		mockDefaultLocation(defaultLocation);
 		mockIdentifierSource(null);
 		
-		generator.generateIdentifier(Integer.valueOf(OPENMRS_IDENTIFIER_SOURCE_ID), null);
+		generator.generateIdentifier(OPENMRS_IDENTIFIER_SOURCE_STRING_ID, null);
 	}
 	
 	@Test
@@ -162,5 +163,20 @@ public class IdentifierBuilderTest {
 		mockDefaultLocation(null);
 		
 		generator.createIdentifier(PERSON_IDENTIFIER_TYPE_UUID, CUSTOM_MPI_IDENTIFIER_VALUE, null);
+	}
+	
+	@Test
+	public void generateIdentifier_shouldConsumeUuidAsSourceId() {
+		String identifierSourceUuid = "0d47284f-9e9b-4a81-a88b-8bb42bc0a901";
+		mockDefaultLocation(defaultLocation);
+		when(iss.getIdentifierSourceByUuid(identifierSourceUuid)).thenReturn(identifierSource);
+		when(identifierSource.getIdentifierType()).thenReturn(identifierType);
+		mockGeneratedIdentifier();
+		
+		PatientIdentifier patientIdentifier = generator.generateIdentifier(identifierSourceUuid, null);
+		
+		assertEquals(OPENMRS_GENERATED_IDENTIFIER, patientIdentifier.getIdentifier());
+		assertEquals(identifierType, patientIdentifier.getIdentifierType());
+		assertEquals(defaultLocation, patientIdentifier.getLocation());
 	}
 }


### PR DESCRIPTION
…ncore.identifierSourceId GlobalProperty

Ticket : https://issues.openmrs.org/browse/RC-32